### PR TITLE
Add missing require

### DIFF
--- a/lib/taskwarrior-web/command_builders/base.rb
+++ b/lib/taskwarrior-web/command_builders/base.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module TaskwarriorWeb::CommandBuilder
   module Base
 


### PR DESCRIPTION
Adding a new task was failing with the following error:

```
NoMethodError at /tasks/new
undefined method `shellescape' for "test":String

file: base.rb
location: parse_params
line: 41
```

The specs are passing because the missing library _shellwords_ that defines `String#shellescape` is included by RSpec (https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/configuration_options.rb#L2).

This patch ensures that _shellwords_ is included even in non-testing environment.
