### PR TITLE
Added support for newer versions of Ruby, taskwarrior and also task server support.

### DIFF
--- a/lib/taskwarrior-web/app.rb
+++ b/lib/taskwarrior-web/app.rb
@@ -29,12 +29,7 @@ class TaskwarriorWeb::App < Sinatra::Base
     @current_page = request.path_info
     @can_edit = TaskwarriorWeb::Config.supports? :editing
     protected! if TaskwarriorWeb::Config.property('task-web.user')
-
-    # If we should be synchronising with the taskwarrior server
-    # make sure we do that before each request.
-    if TaskwarriorWeb::Config.property('taskd.server')
-      TaskwarriorWeb::Task.sync()
-    end
+    sync if TaskwarriorWeb::Config.property('taskd.server')
   end
 
   # Task routes

--- a/lib/taskwarrior-web/app.rb
+++ b/lib/taskwarrior-web/app.rb
@@ -23,12 +23,18 @@ class TaskwarriorWeb::App < Sinatra::Base
   helpers Helpers
   register Sinatra::SimpleNavigation
   use Rack::Flash
-  
+
   # Before filter
   before do
     @current_page = request.path_info
     @can_edit = TaskwarriorWeb::Config.supports? :editing
     protected! if TaskwarriorWeb::Config.property('task-web.user')
+
+    # If we should be synchronising with the taskwarrior server
+    # make sure we do that before each request.
+    if TaskwarriorWeb::Config.property('taskd.server')
+      TaskwarriorWeb::Task.sync()
+    end
   end
 
   # Task routes

--- a/lib/taskwarrior-web/helpers.rb
+++ b/lib/taskwarrior-web/helpers.rb
@@ -86,4 +86,10 @@ module TaskwarriorWeb::App::Helpers
     values = [TaskwarriorWeb::Config.property('task-web.user'), TaskwarriorWeb::Config.property('task-web.passwd')]
     @auth.provided? && @auth.basic? && @auth.credentials && @auth.credentials == values
   end
+
+  ##
+  # Syncronise the local task database with the server
+  def sync
+    TaskwarriorWeb::Command.new(:sync, nil, nil).run
+  end
 end

--- a/lib/taskwarrior-web/model/task.rb
+++ b/lib/taskwarrior-web/model/task.rb
@@ -136,6 +136,17 @@ module TaskwarriorWeb
       end
     end
 
+    ################################################
+    # CLASS METHOD FOR SYNCRONISING WITH TASK SERVER
+    ################################################
+
+    ##
+    # Syncronise the local task database with the server
+    # TODO: These args are going to be ignored!
+    def self.sync(*args)
+      Command.new(:sync, nil, *args).run
+    end
+
   end
 
   ###########################################

--- a/lib/taskwarrior-web/model/task.rb
+++ b/lib/taskwarrior-web/model/task.rb
@@ -136,17 +136,6 @@ module TaskwarriorWeb
       end
     end
 
-    ################################################
-    # CLASS METHOD FOR SYNCRONISING WITH TASK SERVER
-    ################################################
-
-    ##
-    # Syncronise the local task database with the server
-    # TODO: These args are going to be ignored!
-    def self.sync(*args)
-      Command.new(:sync, nil, *args).run
-    end
-
   end
 
   ###########################################

--- a/lib/taskwarrior-web/services/builder/base.rb
+++ b/lib/taskwarrior-web/services/builder/base.rb
@@ -11,8 +11,9 @@ module TaskwarriorWeb::CommandBuilder::Base
     :annotate => ':id annotate',
     :denotate => ':id denotate',
     :projects => '_projects',
-    :tags => '_tags'
-  }    
+    :tags => '_tags',
+    :sync => 'sync'
+  }
 
   def build
     unless @command_string

--- a/lib/taskwarrior-web/services/builder/base.rb
+++ b/lib/taskwarrior-web/services/builder/base.rb
@@ -6,7 +6,7 @@ module TaskwarriorWeb::CommandBuilder::Base
     :add => 'add',
     :update => TaskwarriorWeb::Config.version.major >= 2 ? ':id mod' : nil,
     :delete => 'rc.confirmation=no :id delete',
-    :query => TaskwarriorWeb::Config.version > '1.9.2' ? '_query' : 'export',
+    :query => 'export',
     :complete => ':id done',
     :annotate => ':id annotate',
     :denotate => ':id denotate',

--- a/lib/taskwarrior-web/services/builder/base.rb
+++ b/lib/taskwarrior-web/services/builder/base.rb
@@ -6,7 +6,7 @@ module TaskwarriorWeb::CommandBuilder::Base
     :add => 'add',
     :update => TaskwarriorWeb::Config.version.major >= 2 ? ':id mod' : nil,
     :delete => 'rc.confirmation=no :id delete',
-    :query => 'export',
+    :query => TaskwarriorWeb::Config.version == '1.9.4' ? '_query' : 'export',
     :complete => ':id done',
     :annotate => ':id annotate',
     :denotate => ':id denotate',

--- a/lib/taskwarrior-web/services/parser/json.rb
+++ b/lib/taskwarrior-web/services/parser/json.rb
@@ -4,6 +4,6 @@ module TaskwarriorWeb::Parser::Json
   def self.parse(json)
     json.strip!
     json = '[' + json + ']'
-    json == '[No matches.]' ? [] : ::JSON.parse(json)
+    json == '[No matches.]' ? [] : ::JSON.parse(json.gsub(/\n/,','))
   end
 end

--- a/lib/taskwarrior-web/services/runner.rb
+++ b/lib/taskwarrior-web/services/runner.rb
@@ -1,0 +1,9 @@
+module TaskwarriorWeb::Runner
+  TASK_BIN = 'task rc.xterm.title=no rc.color=off rc.verbose=no rc.confirmation=no'
+
+  def run
+    @built ||= build
+    puts "> #{TASK_BIN} #{@built}"
+    `#{TASK_BIN} #{@built}`
+  end
+end

--- a/lib/taskwarrior-web/services/runner.rb
+++ b/lib/taskwarrior-web/services/runner.rb
@@ -1,8 +1,0 @@
-module TaskwarriorWeb::Runner
-  TASK_BIN = 'task rc.xterm.title=no rc.color=off rc.verbose=no rc.confirmation=no'
-
-  def run
-    @built ||= build
-    `#{TASK_BIN} #{@built}`
-  end
-end

--- a/taskwarrior-web.gemspec
+++ b/taskwarrior-web.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '~> 3')
   s.add_dependency('sinatra-simple-navigation')
   s.add_dependency('rack-flash3')
-  s.add_dependency('json', '~> 1.7.7')
+  s.add_dependency('json', '~> 1.8')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rack-test')


### PR DESCRIPTION
#69 prevents taskwarrior-web from working with newer versions of taskwarrior.
#74 prevents taskwarrior-web from installing on hosts with Ruby 2.2.0 (and maybe others)

This pull request includes fixes for both issues.

I've done some basic testing (navigating to the web page, adding new tasks) to confirm that this all compiles and installs.

EDIT:
I added support for syncing with the task server! It seems inefficient to call 'task sync' at every request, but it's the only way to ensure the task database it up to date. It takes me about 20ms to run 'task sync' with no changes, so I guess that's not too much overhead.