### PR TITLE
🐛 Truncate long annotation to preserve layout width

### DIFF
--- a/lib/taskwarrior-web/public/css/styles.css
+++ b/lib/taskwarrior-web/public/css/styles.css
@@ -88,3 +88,9 @@ table.table thead .sorting_desc { background: url('../img/sort_desc.png') no-rep
 
 table.table thead .sorting_asc_disabled { background: url('../img/sort_asc_disabled.png') no-repeat center right; }
 table.table thead .sorting_desc_disabled { background: url('../img/sort_desc_disabled.png') no-repeat center right; }
+
+.annotation-text {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 20vw;
+}

--- a/lib/taskwarrior-web/views/tasks/index.erb
+++ b/lib/taskwarrior-web/views/tasks/index.erb
@@ -35,15 +35,23 @@
             <td>
               <%= task.description %>
               <% unless task.annotations.empty? %>
-                <ul>
+                <table>
                   <% task.annotations.each do |annotation| %>
-                    <li>
-                      <%= format_date(annotation.entry) %>: <%= auto_link(annotation.description) %>
-                      &nbsp;
-                      <a href="/tasks/<%= task.uuid %>/annotations/<%= ERB::Util.u(annotation.description) %>" data-method="DELETE" data-confirm="Are you sure you want to delete this annotation?"><i class="icon-trash"></i></a>
-                    </li>
+                    <tr>
+                      <td class="annotation-text">
+                        <strong><%= format_date(annotation.entry) %>:</strong>
+                        <%= auto_link(annotation.description) %>
+                      </td>
+                      <td>
+                        <a href="/tasks/<%= task.uuid %>/annotations/<%= ERB::Util.u(annotation.description) %>"
+                           data-method="DELETE"
+                           data-confirm="Are you sure you want to delete this annotation?">
+                          <i class="icon-trash"></i>
+                        </a>
+                      </td>
+                    </tr>
                   <% end %>
-                </ul>
+                </table>
               <% end %>
             </td>
             <td><a href="/projects/<%= linkify(task.project) %>"><%= task.project %></a></td>


### PR DESCRIPTION
Related issue: #105.

I'm not sure if `max-width: 20vw` is a good idea, but it works as a temporary solution, as soon as we don't have responsive design yet.