### PR TITLE
Allow mounting application at a location other than '/' when started with rackup.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,9 @@
 require File.join(File.dirname(__FILE__), 'lib', 'taskwarrior-web')
+require 'sinatra'
 
 disable :run
 TaskwarriorWeb::App.set({ :environment => :production })
-run TaskwarriorWeb::App
+
+map '/' do
+  run TaskwarriorWeb::App
+end

--- a/lib/taskwarrior-web/app.rb
+++ b/lib/taskwarrior-web/app.rb
@@ -11,7 +11,7 @@ require 'rack-flash'
 class TaskwarriorWeb::App < Sinatra::Base
   autoload :Helpers, 'taskwarrior-web/helpers'
 
-  @@root = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+  @@root = File.dirname(__FILE__)
   set :root,  @@root    
   set :app_file, __FILE__
   set :public_folder, File.dirname(__FILE__) + '/public'

--- a/lib/taskwarrior-web/config/navigation.rb
+++ b/lib/taskwarrior-web/config/navigation.rb
@@ -3,16 +3,16 @@ SimpleNavigation::Configuration.run do |navigation|
 
   navigation.items do |primary|
     primary.dom_class = 'nav'
-    primary.item :tasks, 'Tasks', '/tasks' do |tasks|
+    primary.item :tasks, 'Tasks', url('/tasks') do |tasks|
       tasks.dom_class = 'nav nav-pills'
-      tasks.item :pending, "Pending <span class=\"badge\">#{task_count}</span>", '/tasks/pending'
-      tasks.item :waiting, 'Waiting', '/tasks/waiting'
-      tasks.item :completed, 'Completed', '/tasks/completed'
-      tasks.item :deleted, 'Deleted', '/tasks/deleted'
+      tasks.item :pending, "Pending <span class=\"badge\">#{task_count}</span>", url('/tasks/pending')
+      tasks.item :waiting, 'Waiting', url('/tasks/waiting')
+      tasks.item :completed, 'Completed', url('/tasks/completed')
+      tasks.item :deleted, 'Deleted', url('/tasks/deleted')
     end
-    primary.item :projects, 'Projects', '/projects', { :highlights_on => %r{/projects/?.+?} } do |projects|
+    primary.item :projects, 'Projects', url('/projects'), { :highlights_on => %r{/projects/?.+?} } do |projects|
       projects.dom_class = 'nav nav-pills'
-      projects.item :overview, 'Overview', '/projects/overview'
+      projects.item :overview, 'Overview', url('/projects/overview')
     end
   end
 end

--- a/lib/taskwarrior-web/helpers.rb
+++ b/lib/taskwarrior-web/helpers.rb
@@ -67,11 +67,11 @@ module TaskwarriorWeb::App::Helpers
 
   def crud_links(task)
     string = %(<span class="crud-links">)
-    string << %(<a class="annotation-add" href="/tasks/#{task.uuid}/annotations/new"><i class="icon-comment"></i></a>)
+    string << %(<a class="annotation-add" href="#{url("/tasks/#{task.uuid}/annotations/new")}"><i class="icon-comment"></i></a>)
     string << %(&nbsp;|&nbsp;)
-    string << %(<a href="/tasks/#{task.uuid}?destination=#{ERB::Util.u(request.path_info)}"><i class="icon-pencil"></i></a>)
+    string << %(<a href="#{url("/tasks/#{task.uuid}?destination=#{ERB::Util.u(request.path_info)}")}"><i class="icon-pencil"></i></a>)
     string << %(&nbsp;|&nbsp;)
-    string << %(<a href="/tasks/#{task.uuid}?destination=#{ERB::Util.u(request.path_info)}" data-method="DELETE" data-confirm="Are you sure you want to delete this task?"><i class="icon-trash"></i></a>)
+    string << %(<a href="#{url("/tasks/#{task.uuid}?destination=#{ERB::Util.u(request.path_info)}")}" data-method="DELETE" data-confirm="Are you sure you want to delete this task?"><i class="icon-trash"></i></a>)
     string << %(</span>)
     string
   end

--- a/lib/taskwarrior-web/views/404.erb
+++ b/lib/taskwarrior-web/views/404.erb
@@ -1,2 +1,2 @@
 <p>Aww bummer. Taskwarrior doesn't know what to do with <%= @current_page %>.</p>
-<p>Go <a href="<%= back %>">back</a> or <a href="/tasks">to the main task page</a>.</p>
+<p>Go <a href="<%= back %>">back</a> or <a href="<%= url('/tasks') %>">to the main task page</a>.</p>

--- a/lib/taskwarrior-web/views/partials/_topbar.erb
+++ b/lib/taskwarrior-web/views/partials/_topbar.erb
@@ -1,10 +1,10 @@
 <div class="navbar navbar-fixed-top">
   <div class="navbar-inner"><div class="container">
-    <a href="/" class="brand">TaskwarriorWeb</a>
+    <a href="<%= url('/') %>" class="brand">TaskwarriorWeb</a>
     <%= render_navigation :level => 1 %>
     <ul class="nav pull-right">
       <li<% if @current_page =~ %r(^/tasks/new/?) %> class="active"<% end %>>
-        <a href="/tasks/new?destination=<%= ERB::Util.u(request.path_info) %>">
+        <a href="<%= url("/tasks/new?destination=#{ERB::Util.u(request.path_info)}") %>">
           <i class="icon-plus"></i>&nbsp;Add a Task
         </a>
       </li>

--- a/lib/taskwarrior-web/views/tasks/_annotation_form.erb
+++ b/lib/taskwarrior-web/views/tasks/_annotation_form.erb
@@ -1,4 +1,4 @@
-<form action="/tasks/<%= @task.uuid %>/annotations" method="POST" class="modal-form">
+<form action="<%= url("/tasks/#{@task.uuid}/annotations") %>" method="POST" class="modal-form">
   <div class="modal-header">
     <% if @json %>
       <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>

--- a/lib/taskwarrior-web/views/tasks/_form.erb
+++ b/lib/taskwarrior-web/views/tasks/_form.erb
@@ -23,7 +23,7 @@
   <label for="task-wait" class="control-label">Hide until</label>
   <div class="controls">
     <input class="date-picker" type="text" id="task-wait" name="task[wait]" value="<%= format_date(@task.wait) unless @task.nil? || @task.wait.blank? %>" data-date-format="<%= @date_format %>" />
-    <span class="help-block">If specified, the task will appear in the <a href="/tasks/waiting">Waiting</a> list until the given date.</span>
+    <span class="help-block">If specified, the task will appear in the <a href="<%= url('/tasks/waiting') %>">Waiting</a> list until the given date.</span>
   </div>
 </div>
 

--- a/lib/taskwarrior-web/views/tasks/index.erb
+++ b/lib/taskwarrior-web/views/tasks/index.erb
@@ -43,7 +43,7 @@
                         <%= auto_link(annotation.description) %>
                       </td>
                       <td>
-                        <a href="/tasks/<%= task.uuid %>/annotations/<%= ERB::Util.u(annotation.description) %>"
+                        <a href="<%= url("/tasks/#{task.uuid}/annotations/#{ERB::Util.u(annotation.description)}") %>"
                            data-method="DELETE"
                            data-confirm="Are you sure you want to delete this annotation?">
                           <i class="icon-trash"></i>
@@ -54,7 +54,7 @@
                 </table>
               <% end %>
             </td>
-            <td><a href="/projects/<%= linkify(task.project) %>"><%= task.project %></a></td>
+            <td><a href="<%= url("/projects/#{linkify(task.project)}") %>"><%= task.project %></a></td>
             <td><%= format_date(task.due) unless task.due.nil? %></td>
             <%= 
               case params[:status]

--- a/lib/taskwarrior-web/views/tasks/new.erb
+++ b/lib/taskwarrior-web/views/tasks/new.erb
@@ -4,7 +4,7 @@
   });
 </script>
 
-<form id="new-task-form" class="form-horizontal" action="/tasks<%= '?destination='+ERB::Util.u(params[:destination]) if params[:destination] %>" method="post">
+<form id="new-task-form" class="form-horizontal" action="<%= url('/tasks') %><%= '?destination='+ERB::Util.u(params[:destination]) if params[:destination] %>" method="post">
 
   <%= erb :'tasks/_form' %>
 


### PR DESCRIPTION
I needed to mount my todo list at `mypersonalsubdomain/task-web`. However, links were hard-coded in several places. I have modified them to generate correct links using the `url` function.

I had to change `@@root` so that `sinatra/simple-navigation` will pick up the configuration file in `/lib/taskwarrior-web/config` instead of looking in `/config`. This works for me with `rackup`, but I don't know if it breaks something when used with `vegas`.

All the other changes should be safe.