### PR TITLE
Fix parse error when 'task _version' returns the commit hash

### DIFF
--- a/lib/taskwarrior-web/model/config.rb
+++ b/lib/taskwarrior-web/model/config.rb
@@ -41,7 +41,7 @@ module TaskwarriorWeb::Config
   }
 
   def self.version
-    @version ||= Versionomy.parse(`#{TaskwarriorWeb::Runner::TASK_BIN} _version`.strip)
+    @version ||= Versionomy.parse(`#{TaskwarriorWeb::Runner::TASK_BIN} _version`.strip.split[0])
   end
 
   def self.store


### PR DESCRIPTION
When taskwarrior is compiled from the git repository (for instance using the AUR package `task-git`), the command `task _version` returns the git commit hash :
```
$ task _version
2.6.0 (d01000e25)
```
This creates an error : 
```
2019-04-19 15:36:21 - Versionomy::Errors::ParseError - Extra characters: " (d01000e25)":
        /home/gguy/.gem/gems/versionomy-0.5.0/lib/versionomy/format/delimiter.rb:199:in `parse'
        /home/gguy/.gem/gems/versionomy-0.5.0/lib/versionomy/interface.rb:130:in `parse'
        /home/gguy/projects/logiciels/taskwarrior-web/lib/taskwarrior-web/model/config.rb:44:in `version'
        /home/gguy/projects/logiciels/taskwarrior-web/lib/taskwarrior-web/model/config.rb:68:in `supports?'
        /home/gguy/projects/logiciels/taskwarrior-web/lib/taskwarrior-web/app.rb:30:in `block in <class:App>'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1635:in `call'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1635:in `block in compile!'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1040:in `block in process_route'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1038:in `catch'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1038:in `process_route'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:983:in `block in filter!'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:983:in `each'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:983:in `filter!'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1096:in `block in dispatch!'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1076:in `block in invoke'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1076:in `catch'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1076:in `invoke'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1094:in `dispatch!'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:924:in `block in call!'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1076:in `block in invoke'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1076:in `catch'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1076:in `invoke'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:924:in `call!'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:913:in `call'
        /home/gguy/.gem/gems/rack-flash3-1.0.5/lib/rack/flash.rb:124:in `call'
        /home/gguy/.gem/gems/rack-protection-2.0.5/lib/rack/protection/xss_header.rb:18:in `call'
        /home/gguy/.gem/gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
        /home/gguy/.gem/gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
        /home/gguy/.gem/gems/rack-protection-2.0.5/lib/rack/protection/path_traversal.rb:16:in `call'
        /home/gguy/.gem/gems/rack-protection-2.0.5/lib/rack/protection/json_csrf.rb:26:in `call'
        /home/gguy/.gem/gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
        /home/gguy/.gem/gems/rack-protection-2.0.5/lib/rack/protection/base.rb:50:in `call'
        /home/gguy/.gem/gems/rack-protection-2.0.5/lib/rack/protection/frame_options.rb:31:in `call'
        /home/gguy/.gem/gems/rack-2.0.7/lib/rack/session/abstract/id.rb:232:in `context'
        /home/gguy/.gem/gems/rack-2.0.7/lib/rack/session/abstract/id.rb:226:in `call'
        /home/gguy/.gem/gems/rack-2.0.7/lib/rack/null_logger.rb:9:in `call'
        /home/gguy/.gem/gems/rack-2.0.7/lib/rack/head.rb:12:in `call'
        /home/gguy/.gem/gems/rack-2.0.7/lib/rack/method_override.rb:22:in `call'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/show_exceptions.rb:22:in `call'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:194:in `call'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1957:in `call'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1502:in `block in call'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1729:in `synchronize'
        /home/gguy/.gem/gems/sinatra-2.0.5/lib/sinatra/base.rb:1502:in `call'
        /home/gguy/.gem/gems/rack-2.0.7/lib/rack/handler/webrick.rb:86:in `service'
        /usr/lib/ruby/2.6.0/webrick/httpserver.rb:140:in `service'
        /usr/lib/ruby/2.6.0/webrick/httpserver.rb:96:in `run'
        /usr/lib/ruby/2.6.0/webrick/server.rb:307:in `block in start_thread'
```